### PR TITLE
[Feature] Feedback 작동 확인 및 ML 서비스 관련 코드 수정

### DIFF
--- a/src/main/java/com/example/vegetabledragon/controller/FeedbackController.java
+++ b/src/main/java/com/example/vegetabledragon/controller/FeedbackController.java
@@ -1,6 +1,7 @@
 package com.example.vegetabledragon.controller;
 
 import com.example.vegetabledragon.domain.UserFeedback;
+import com.example.vegetabledragon.dto.FakeNewsFeedbackRatioResponse;
 import com.example.vegetabledragon.dto.FeedbackRequest;
 import com.example.vegetabledragon.exception.PostNotFoundException;
 import com.example.vegetabledragon.exception.UserNotFoundException;
@@ -40,8 +41,8 @@ public class FeedbackController {
 
     // 특정 게시글의 가짜 뉴스 비율 조회
     @GetMapping("/{postId}/ratio")
-    public ResponseEntity<Map<String, Double>> getFakeNewsRatio(@PathVariable Long postId) throws PostNotFoundException {
-        Map<String, Double> ratio = userFeedbackService.getFakeNewsFeedbackRatio(postId);
-        return ResponseEntity.ok(ratio);
+    public ResponseEntity<FakeNewsFeedbackRatioResponse> getFakeNewsRatio(@PathVariable Long postId) throws PostNotFoundException {
+        FakeNewsFeedbackRatioResponse response = userFeedbackService.getFakeNewsFeedbackRatio(postId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/vegetabledragon/controller/MLController.java
+++ b/src/main/java/com/example/vegetabledragon/controller/MLController.java
@@ -1,36 +1,37 @@
 package com.example.vegetabledragon.controller;
+import com.example.vegetabledragon.domain.Post;
+import com.example.vegetabledragon.exception.PostNotFoundException;
 import com.example.vegetabledragon.service.MLService;
-import com.example.vegetabledragon.service.MLServiceImpl;
+import com.example.vegetabledragon.service.PostService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.Map;
+import java.util.Optional;
 
 @CrossOrigin(origins = "http://localhost:5173")
 @RestController
 @RequestMapping("/api")
+@Slf4j
+@RequiredArgsConstructor
 public class MLController {
     private final MLService mlService;
-
-    public MLController(MLService mlService) {
-        this.mlService = mlService;
-    }
+    private final PostService postService;
 
     // vue.js에서 입력받은 데이터를 flask api로 전달
-    @PostMapping("/predict")
-    public ResponseEntity<Map<String, Object>> callPythonAPI(@RequestBody Map<String, String> request) {
-        System.out.println("[Spring Boot] 받은 요청 데이터: " + request);
+    @PostMapping("/predict/{postId}")
+    public ResponseEntity<Map<String, Object>> callPythonAPI(@PathVariable Long postId) throws PostNotFoundException {
 
-        String userText = request.get("text");
-        if (userText == null || userText.trim().isEmpty()) {
-            System.out.println("[Spring Boot] 텍스트가 없습니다!");
-            return ResponseEntity.badRequest().body(Map.of("error", "Invalid input"));
-        }
+        Post post = postService.getPostById(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+
+        String postContent = post.getContent();
+        log.info("[MLController] 게시글 내용 : {}", postContent);
 
         // Flask API 호출
-        Map<String, Object> result = mlService.predict(userText);
-        System.out.println("✅ [Spring Boot] Flask 응답: " + result);
+        Map<String, Object> result = mlService.predict(postContent);
+        log.debug("[MLController] Flask 응답: " + result);
 
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/example/vegetabledragon/domain/Prediction.java
+++ b/src/main/java/com/example/vegetabledragon/domain/Prediction.java
@@ -1,0 +1,28 @@
+package com.example.vegetabledragon.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Prediction {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Column(nullable = true)
+    private Double predictionScore;
+
+    public Prediction(Post post, Double predictionScore) {
+        this.post = post;
+        this.predictionScore = predictionScore;
+    }
+}

--- a/src/main/java/com/example/vegetabledragon/domain/UserFeedback.java
+++ b/src/main/java/com/example/vegetabledragon/domain/UserFeedback.java
@@ -28,7 +28,7 @@ public class UserFeedback {
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    private User user;  
 
     @Column(nullable = false)
     private boolean isFakeNews; // true면 가짜뉴스, false면 진짜뉴스

--- a/src/main/java/com/example/vegetabledragon/dto/FakeNewsFeedbackRatioResponse.java
+++ b/src/main/java/com/example/vegetabledragon/dto/FakeNewsFeedbackRatioResponse.java
@@ -1,0 +1,20 @@
+package com.example.vegetabledragon.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FakeNewsFeedbackRatioResponse {
+    private long fakeNewsCount;
+    private long trueNewsCount;
+    private double fakeNewsRatio;
+    private double trueNewsRatio;
+
+    public FakeNewsFeedbackRatioResponse(long fakeNewsCount, long trueNewsCount, double fakeNewsRatio, double trueNewsRatio) {
+        this.fakeNewsCount = fakeNewsCount;
+        this.trueNewsCount = trueNewsCount;
+        this.fakeNewsRatio = fakeNewsRatio;
+        this.trueNewsRatio = trueNewsRatio;
+    }
+}

--- a/src/main/java/com/example/vegetabledragon/service/UserFeedbackService.java
+++ b/src/main/java/com/example/vegetabledragon/service/UserFeedbackService.java
@@ -1,6 +1,7 @@
 package com.example.vegetabledragon.service;
 
 import com.example.vegetabledragon.domain.UserFeedback;
+import com.example.vegetabledragon.dto.FakeNewsFeedbackRatioResponse;
 import com.example.vegetabledragon.dto.FeedbackRequest;
 import com.example.vegetabledragon.exception.PostNotFoundException;
 import com.example.vegetabledragon.exception.UserNotFoundException;
@@ -16,5 +17,5 @@ public interface UserFeedbackService {
     List<UserFeedback> getFeedbacksByPost(Long postId) throws PostNotFoundException;
 
     // 특정 게시글의 가짜뉴스 비율 조회
-    Map<String, Double> getFakeNewsFeedbackRatio(Long postId) throws PostNotFoundException;
+    FakeNewsFeedbackRatioResponse getFakeNewsFeedbackRatio(Long postId) throws PostNotFoundException;
 }

--- a/src/main/java/com/example/vegetabledragon/service/UserFeedbackServiceImpl.java
+++ b/src/main/java/com/example/vegetabledragon/service/UserFeedbackServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.vegetabledragon.service;
 import com.example.vegetabledragon.domain.Post;
 import com.example.vegetabledragon.domain.User;
 import com.example.vegetabledragon.domain.UserFeedback;
+import com.example.vegetabledragon.dto.FakeNewsFeedbackRatioResponse;
 import com.example.vegetabledragon.dto.FeedbackRequest;
 import com.example.vegetabledragon.exception.PostNotFoundException;
 import com.example.vegetabledragon.exception.UserNotFoundException;
@@ -58,7 +59,7 @@ public class UserFeedbackServiceImpl implements UserFeedbackService {
     }
 
     @Override
-    public Map<String, Double> getFakeNewsFeedbackRatio(Long postId) throws PostNotFoundException {
+    public FakeNewsFeedbackRatioResponse getFakeNewsFeedbackRatio(Long postId) throws PostNotFoundException {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostNotFoundException(postId));
 
@@ -66,12 +67,15 @@ public class UserFeedbackServiceImpl implements UserFeedbackService {
         long trueNewsCount = userFeedbackRepository.countByPostAndIsFakeNewsFalse(post);
         long total = fakeNewsCount + trueNewsCount;
 
-        if (total == 0)
-            return Map.of("fakeNewsRatio", 0.0, "trueNewsRatio", 0.0);
+        double fakeNewsRatio = 0;
+        double trueNewsRatio = 0;
 
-        return Map.of(
-                "fakeNewsRatio", (double) fakeNewsCount / total,
-                "trueNewsRatio", (double) trueNewsCount / total
-        );
+        if (total > 0){
+            fakeNewsRatio = (double) fakeNewsCount / total;
+            trueNewsRatio = (double) trueNewsCount / total;
+        }
+
+
+        return new FakeNewsFeedbackRatioResponse(fakeNewsCount, trueNewsCount, fakeNewsRatio, trueNewsRatio);
     }
 }


### PR DESCRIPTION
[2025.04.04]

### 내용 : 
- **Post와 MLController 통합** : 기존에 예측확률을 얻으려면 Request Body에 내용을 직접 채워서 요청을 보내야했던 방식에서,  `postId`를 통해 Post의 content를 추출하여 이를 `ML 서버` 에 전달하고 예측 결과를 받아오는 방식으로 코드를 변경하였습니다.

- **UserFeedback Response 수정** :  가짜 뉴스라고 답한 사람의 비율만 가져오던 부분에서 **가짜 뉴스**라고 응답한 사람과 **진짜 뉴스**라고 응답한 `사람의 수 및 비율`까지 포함하도록 `Response 엔티티`를 수정하여, 더 구분이 용이하도록 개선했습니다.

### 검토 사항:
- **ML 서버와의 연동**: 이전에 잘 작동하던 부분을 **Post**에서 `content`를 추출하여 ML 서버에 전달하는 방식으로 변경했으므로, 예상대로 잘 작동할 것으로 예상됩니다. 하지만 혹시 모르므로, ML 모델의 기초가 만들어지는 대로 더미데이터를 넣어서 테스트를 우선적으로 진행해야 합니다.