### PR TITLE
[Unit Test + Logging 개선] 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-web-services'
 
+    // Spring AOP
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
     // spring Security
     implementation "org.springframework.boot:spring-boot-starter-security"
     implementation "org.springframework.security:spring-security-test"
@@ -53,6 +56,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+
 
 
 }

--- a/src/main/java/com/example/vegetabledragon/LoggingAspect.java
+++ b/src/main/java/com/example/vegetabledragon/LoggingAspect.java
@@ -1,0 +1,41 @@
+package com.example.vegetabledragon;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Aspect // AOP를 처리하는 클래스임을 알려줌.
+@Component // 스프링 빈으로 등록.
+public class LoggingAspect {
+    private static final Logger logger = LoggerFactory.getLogger(LoggingAspect.class);
+
+    // Before, After -> 메소드가 언제 실행되고 종료되는지를 알기 위함.
+    // 메서드 실행 전 로그 남기기
+    @Before("execution(* com.example.vegetabledragon.service.*.*(..))")
+    public void logBefore(JoinPoint joinPoint) {
+        logger.info("Entering method: " + joinPoint.getSignature().toShortString());
+    }
+
+    // 메서드 실행 후 로그 남기기
+    @After("execution(* com.example.vegetabledragon.service.*.*(..))")
+    public void logAfter(JoinPoint joinPoint) {
+        logger.info("Exiting method: " + joinPoint.getSignature().toShortString());
+    }
+
+    // 실행 결과 확인
+    @Around("execution(* com.example.vegetabledragon.service.*.*(..))")
+    public Object logAround(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object result = joinPoint.proceed(); // 메소드 실행
+
+        logger.info("Method execution finished: " + joinPoint.getSignature().toShortString());
+        logger.info("Result: " + result);
+
+        return result;
+    }
+}

--- a/src/main/java/com/example/vegetabledragon/config/AppConfig.java
+++ b/src/main/java/com/example/vegetabledragon/config/AppConfig.java
@@ -6,10 +6,12 @@ import com.example.vegetabledragon.service.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
+@EnableAspectJAutoProxy // AOP 활성화
 public class AppConfig {
     @Bean
     public PostService postService(PostRepository postRepository, UserRepository userRepository) {

--- a/src/main/java/com/example/vegetabledragon/controller/CommentController.java
+++ b/src/main/java/com/example/vegetabledragon/controller/CommentController.java
@@ -59,12 +59,12 @@ public class CommentController {
         String sessionsUsername = (String) session.getAttribute("loggedInUser");
 
         try {
-            log.info("[CommentController] 댓글 번호 - {} 삭제, 권한 요청 사용자 - {}", commentId, sessionsUsername);
+//            log.info("[CommentController] 댓글 번호 - {} 삭제, 권한 요청 사용자 - {}", commentId, sessionsUsername);
             commentService.deleteComment(commentId, sessionsUsername, request.getPassword());
-            log.info("[CommentController] 댓글 번호 - {} 성공적으로 삭제", commentId);
+//            log.info("[CommentController] 댓글 번호 - {} 성공적으로 삭제", commentId);
             return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
         } catch (CommentNotPermissionException e) {
-            log.error("[CommentController] 댓글 번호 - {} 소유자가 아닌 사용자가 삭제 시도 - {}", commentId, sessionsUsername);
+//            log.error("[CommentController] 댓글 번호 - {} 소유자가 아닌 사용자가 삭제 시도 - {}", commentId, sessionsUsername);
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
     }

--- a/src/main/java/com/example/vegetabledragon/controller/MLController.java
+++ b/src/main/java/com/example/vegetabledragon/controller/MLController.java
@@ -27,11 +27,11 @@ public class MLController {
                 .orElseThrow(() -> new PostNotFoundException(postId));
 
         String postContent = post.getContent();
-        log.info("[MLController] 게시글 내용 : {}", postContent);
+//        log.info("[MLController] 게시글 내용 : {}", postContent);
 
         // Flask API 호출
         Map<String, Object> result = mlService.predict(postContent);
-        log.debug("[MLController] Flask 응답: " + result);
+//        log.debug("[MLController] Flask 응답: " + result);
 
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/example/vegetabledragon/controller/PostController.java
+++ b/src/main/java/com/example/vegetabledragon/controller/PostController.java
@@ -34,14 +34,14 @@ public class PostController {
     public ResponseEntity<Page<Post>> getAllPosts(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) throws InvalidPageSizeException {
-        log.info("[PostController] 게시글 목록 조회 - 페이지 : {}, 사이즈 : {}", page, size);
+//        log.info("[PostController] 게시글 목록 조회 - 페이지 : {}, 사이즈 : {}", page, size);
         return ResponseEntity.ok(postService.getAllPosts(page, size));
     }
 
     // 특정 게시글 조회
     @GetMapping("/{postId}")
     public ResponseEntity<Post> getPostById(@PathVariable Long postId) throws PostNotFoundException {
-        log.info("[PostController] 특정 게시글 조회 - 게시글 ID: {}", postId);
+//        log.info("[PostController] 특정 게시글 조회 - 게시글 ID: {}", postId);
         return postService.getPostById(postId)
                 .map(ResponseEntity::ok)
                 .orElseThrow(() -> new PostNotFoundException(postId));
@@ -50,18 +50,18 @@ public class PostController {
     // 게시글 삭제
     @DeleteMapping("/{postId}")
     public ResponseEntity<Void> deletePostById(@PathVariable Long postId, HttpSession session) throws PostNotFoundException, UnauthorizedException {
-        log.info("[PostController] 게시글 삭제 - 게시글 ID: {}", postId);
+//        log.info("[PostController] 게시글 삭제 - 게시글 ID: {}", postId);
         postService.deletePostById(postId, session);
-        log.info("[PostController] 게시글 삭제 완료");
+//        log.info("[PostController] 게시글 삭제 완료");
         return ResponseEntity.noContent().build();
     }
 
     // 게시글 수정
     @PutMapping("/{postId}")
     public ResponseEntity<Post> updatePostById(@PathVariable Long postId, @RequestBody PostRequest request, HttpSession session) throws PostNotFoundException, InvalidPostFieldException, UnauthorizedException {
-        log.info("[PostController] 게시글 수정 - 게시글 ID: {}", postId);
+//        log.info("[PostController] 게시글 수정 - 게시글 ID: {}", postId);
         Post updatedPost = postService.updatePost(postId, request, session);
-        log.info("[PostController] 게시글 수정 완료");
+//        log.info("[PostController] 게시글 수정 완료");
         return ResponseEntity.ok(updatedPost);
     }
 

--- a/src/main/java/com/example/vegetabledragon/controller/PostController.java
+++ b/src/main/java/com/example/vegetabledragon/controller/PostController.java
@@ -23,9 +23,9 @@ public class PostController {
     public ResponseEntity<Post> createPost(@RequestBody PostRequest request, HttpSession session) throws InvalidPostFieldException, UserNotFoundException {
         String loggedInUser = (String) session.getAttribute("loggedInUser");
 
-        log.debug("[PostController] createPost() 실행됨");  // 디버깅 로그
+//        log.debug("[PostController] createPost() 실행됨");  // 디버깅 로그
         Post savedPost = postService.createPost(loggedInUser, request);
-        log.info("[PostController] 저장된 Post ID: " + savedPost.getId());
+//        log.info("[PostController] 저장된 Post ID: " + savedPost.getId());
         return ResponseEntity.ok(savedPost);
     }
 

--- a/src/main/java/com/example/vegetabledragon/dto/PostRequest.java
+++ b/src/main/java/com/example/vegetabledragon/dto/PostRequest.java
@@ -8,5 +8,8 @@ import lombok.Setter;
 public class PostRequest {
     private String title;
     private String content;
+
+    public PostRequest(String postTitle, String postContent) {
+    }
 //    private String anonymousName; 직접 테이블에서 찾아오기로 수정
 }

--- a/src/main/java/com/example/vegetabledragon/service/MLServiceImpl.java
+++ b/src/main/java/com/example/vegetabledragon/service/MLServiceImpl.java
@@ -27,7 +27,7 @@ public class MLServiceImpl implements MLService {
 
     @Override
     public Map<String, Object> predict(String text) {
-        log.info("[Spring Boot] MLService, predict 실행 응답: " + text);
+//        log.info("[Spring Boot] MLService, predict 실행 응답: " + text);
 
 
         // Header 설정
@@ -42,7 +42,7 @@ public class MLServiceImpl implements MLService {
         try{
             ObjectMapper objectMapper = new ObjectMapper();
             String jsonBody = objectMapper.writeValueAsString(requestBody);
-            log.info("Generated Request Body: " + jsonBody);
+//            log.info("Generated Request Body: " + jsonBody);
         } catch (Exception e){
             e.printStackTrace();
         }
@@ -52,12 +52,12 @@ public class MLServiceImpl implements MLService {
 
         // Flask API 호출 (POST 요청)
         try {
-            log.debug("[Spring Boot] Flask로 요청을 보냅니다: " + flaskApiUrl);
+//            log.debug("[Spring Boot] Flask로 요청을 보냅니다: " + flaskApiUrl);
             Map response = restTemplate.postForObject(flaskApiUrl, request, Map.class);
-            log.info("[Spring Boot] Flask 응답: " + response);
+//            log.info("[Spring Boot] Flask 응답: " + response);
             return response;
         } catch (Exception e) {
-            log.warn("[Spring Boot] Flask 요청 실패: " + e.getMessage());
+//            log.warn("[Spring Boot] Flask 요청 실패: " + e.getMessage());
             throw new MLServiceException("Flask 요청 실패", e);
         }
     }

--- a/src/main/java/com/example/vegetabledragon/service/UserFeedbackServiceImpl.java
+++ b/src/main/java/com/example/vegetabledragon/service/UserFeedbackServiceImpl.java
@@ -31,7 +31,7 @@ public class UserFeedbackServiceImpl implements UserFeedbackService {
     @Override
     @Transactional
     public UserFeedbackResponse saveFeedback(Long postId, String username, FeedbackRequest request) throws UserNotFoundException, PostNotFoundException {
-        log.debug("[DEBUG] saveFeedback() 호출됨 - username: " + username);
+//        log.debug("[DEBUG] saveFeedback() 호출됨 - username: " + username);
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostNotFoundException(postId));
         User user = userRepository.findByUsername(username)
@@ -54,7 +54,7 @@ public class UserFeedbackServiceImpl implements UserFeedbackService {
         UserFeedback saved = userFeedbackRepository.save(newFeedback);
 
         // Hibernate 로그를 줄이고, 스프링 로그로 생성
-        log.info("[UserfeedbackService_vote] User '{}' voted on Post {} -> fakeNews = {}", user.getUsername(), post.getId(), request.isFakeNews());
+//        log.info("[UserfeedbackService_vote] User '{}' voted on Post {} -> fakeNews = {}", user.getUsername(), post.getId(), request.isFakeNews());
 
         return UserFeedbackResponse.from(saved);
     }

--- a/src/test/java/com/example/vegetabledragon/PostControllerTest.java
+++ b/src/test/java/com/example/vegetabledragon/PostControllerTest.java
@@ -1,0 +1,76 @@
+package com.example.vegetabledragon;
+
+import com.example.vegetabledragon.controller.PostController;
+import com.example.vegetabledragon.domain.Post;
+import com.example.vegetabledragon.dto.PostRequest;
+import com.example.vegetabledragon.service.PostService;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+public class PostControllerTest {
+
+    @Mock
+    private PostService postService;
+
+    @Mock
+    private HttpSession session;
+
+    @InjectMocks
+    private PostController postController; // PostController에 Mock 객체 주입
+
+    private MockMvc mockMvc; // 이게 뭐묘
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(postController).build();
+    }
+
+    @Test
+    @DisplayName("포스트 생성 작동 확인")
+    void createPost_shouldReturnOk() throws Exception{
+        // PostService에서 가져온 authorUsername이 세션의 loggedInUser하고 같은지 확인.
+
+        // Given
+        String loggedInUser = "test";
+        PostRequest postRequest = new PostRequest("Post Title", "Post Content");
+        Post savedPost = new Post("Post Title", "Post Content", loggedInUser);
+        savedPost.setId(1L);
+
+        // Mocking : PostService의 createPost 메소드가 호출될 때 가짜 Post 객체 반환 -> loggedInUser하고 postRequest받으면 savedPost 반환
+        // eq(loggedInUser)를 통해서 세션 사용자와 loggedInUser가 같은지 확인.
+        when(postService.createPost(eq(loggedInUser), any(PostRequest.class))).thenReturn(savedPost);
+
+        // when : HTTP Post 요청 수행
+        mockMvc.perform(post("/posts")
+                .contentType("application/json")
+                .content("{\"title\" : \"Post Title\", \"content\" : \"Post Content\" }")
+                        .sessionAttr("loggedInUser", loggedInUser))
+
+        // Then: 상태 코드와 응답 내용을 검증
+                .andExpect(status().isOk()) // HTTP 200 OK 상태 코드 확인
+                .andExpect(jsonPath("$.id").value(1L)) // 반환된 Post 객체의 id가 1L인지 확인
+                .andExpect(jsonPath("$.title").value("Post Title"))
+                .andExpect(jsonPath("$.content").value("Post Content"))
+                .andExpect(jsonPath("$.authorUsername").value(loggedInUser));
+
+        verify(postService, times(1)).createPost(eq(loggedInUser), any(PostRequest.class));
+
+    }
+
+}


### PR DESCRIPTION
AOP를 적용하여 로깅을 일괄적으로 처리하였습니다.
이전에 `log.info`를 각 메소드마다 작성하는 방식으로 사용했는데, 번거롭고 중복되는 코드가 많다고 생각하여, AOP를 사용하여 공통된 로깅 기능을 적용하였습니다.
예외를 따로 처리하지는 못하여, 추후 개선할 예정입니다.

`PostController`에서 createPost에 대한 단위테스트를 작성하였고, `MLController`, `CommentController`, `JoinController`, `UserFeedbacController`에도 동일한 단위테스트를 적용할 예정입니다.

