### PR TITLE
[Feature] 로그인 세션 유지 확인 및 로그인 성공 화면 연결 

### DIFF
--- a/frontend/src/components/LoginBanner.vue
+++ b/frontend/src/components/LoginBanner.vue
@@ -35,7 +35,7 @@ export default {
         email: '',
         password: ''
       },
-      userName: localStorage.getItem("username") || ''
+      userName: ''
     };
   },
   computed: {
@@ -44,8 +44,8 @@ export default {
     }
   },
   methods: {
-    login() {
-      fetch("http://localhost:8080/login", {
+    login() { // 8080 -> 8081로 변경
+      fetch("http://localhost:8081/join/login", {
         method: "POST",
         headers: {
           "Content-Type": "application/json"
@@ -61,17 +61,36 @@ export default {
           })
           .then((username) => {
             this.userName = username;
-            localStorage.setItem("username", username);
+            localStorage.setItem("username", username); // localstorage를 써서, UserLogin 에서도 username을 가져올 수 있도록 함.
             alert(`환영합니다, ${username}님!`);
           })
           .catch((err) => {
             alert("로그인 실패: " + err.message);
           });
     },
-    logout() {
-      localStorage.removeItem("username");
-      this.userName = '';
+    logout() { // 로그아웃 연결
+      fetch("http://localhost:8081/join/logout", {
+        method: "POST",
+        credentials: "include"
+      })
+      .then(() => {
+        localStorage.removeItem("username");
+        this.userName = '';
+      })
+
+    },
+    syncUserName() {
+      this.userName = localStorage.getItem("username") || '';
+
     }
+  },
+  mounted() {
+    this.syncUserName();
+    window.addEventListener("storage", this.syncUserName);
+
+  },
+  beforeMount() {
+    window.removeEventListener("storage", this.syncUserName);
   }
 };
 </script>

--- a/frontend/src/views/UserLogin.vue
+++ b/frontend/src/views/UserLogin.vue
@@ -46,6 +46,8 @@ export default {
 
         // 서버 응답이 성공 형태인지 확인 (서버 응답 구조에 따라 조정)
         if (result.success !== false) {
+          const username = result.username || this.email;
+          localStorage.setItem('username', username);
           alert('로그인 성공!');
           this.$router.push('/');
         } else {

--- a/src/main/java/com/example/vegetabledragon/controller/JoinController.java
+++ b/src/main/java/com/example/vegetabledragon/controller/JoinController.java
@@ -30,7 +30,7 @@ public class JoinController {
         String username = joinService.login(loginForm);
         if (username != null) {
             session.setAttribute("loggedInUser", username); // 세션에 로그인한 사용자 저장
-            return ResponseEntity.ok("로그인 성공");
+            return ResponseEntity.ok(username);
         }
         return ResponseEntity.status(401).body("로그인 실패");
     }

--- a/src/main/java/com/example/vegetabledragon/domain/Post.java
+++ b/src/main/java/com/example/vegetabledragon/domain/Post.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @NoArgsConstructor
+
 @AllArgsConstructor
 @Table(name="posts")
 public class Post {


### PR DESCRIPTION
1. 로그인 시에 세션이 유지되는 것은 확인했으나, `username` 을 컴포넌트 간 공유하지 못해서 UI 로직이 작동하지 않는 문제를 발견했습니다.
2. 이를 해결하기 위해 `localstorage`에 `username`을  저장하여 다른 컴포넌트에서도 접근 가능하도록 하였습니다.
3. logout 기능도 연결하였습니다.
 - 단, 로그아웃 이후에도 JSESSIONID 쿠키는 남아있는 상태로, 추후 게시글 작성 등에서 문제가 발생한다면 세션을 아예 무효화하거나, 세션의 유효성을 확인하는 로직을 백엔드에 추가해야할 것 같습니다.