### PR TITLE
Comment 도메인 에러 처리 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ dependencies {
 //    implementation 'org.springdoc:springdoc-openapi-ui:1.6.14'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
+    // validation
+    implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 
     // Test 관련 의존성
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/frontend/src/views/board/BoardDetail.vue
+++ b/frontend/src/views/board/BoardDetail.vue
@@ -443,16 +443,14 @@ export default {
       this.confirmingEditComment = this.isLoggedIn;  // 로그인 사용자는 비밀번호 없이 바로 수정 가능
     },
     confirmEditComment() {
-      const comment = this.comments[this.editingCommentIndex];
       if (!this.editCommentPassword.trim()) {
         alert("비밀번호를 입력하세요.");
         return;
       }
-      if (this.editCommentPassword === comment.password) {
-        this.confirmingEditComment = true;
-      } else {
-        alert("비밀번호가 일치하지 않거나 삭제 권한이 없습니다.");
-      }
+
+      // 여기서 password를 임시 저장
+      this._tempEditPassword = this.editCommentPassword;
+      this.confirmingEditComment = true;
     },
     async saveEditComment() {
       const comment = this.comments[this.editingCommentIndex];
@@ -461,7 +459,7 @@ export default {
 
       const requestBody = {
         comment: this.editCommentText,
-        password: this.isLoggedIn ? "LOGIN_USER" : this.editCommentPassword
+        password: this.isLoggedIn ? "LOGIN_USER" : this._tempEditPassword
       };
 
       try {

--- a/src/main/java/com/example/vegetabledragon/apiPayload/ApiResponse.java
+++ b/src/main/java/com/example/vegetabledragon/apiPayload/ApiResponse.java
@@ -1,0 +1,35 @@
+package com.example.vegetabledragon.apiPayload;
+// 원래는 성공한 경우에도 해당 필드를 사용해야하나,
+// 일단 실패한 경우만 처리하도록 함.
+
+/*
+* API Response
+* {
+* "isSuccess" : Boolean,
+* "code" : HTTP 상태 코드 + 세부
+* "message" : "어떤 결과인지 설명",
+* "result" : 응답에 필요한 DTO
+* }
+*/
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+    private final T result;
+
+    // 실패했을 경우
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+        return new ApiResponse<T>(false, code, message, data);
+    }
+}

--- a/src/main/java/com/example/vegetabledragon/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/com/example/vegetabledragon/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,6 @@
+package com.example.vegetabledragon.apiPayload.code;
+
+public interface BaseErrorCode {
+    ErrorReasonDTO getReason();
+    ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/example/vegetabledragon/apiPayload/code/ErrorReasonDTO.java
+++ b/src/main/java/com/example/vegetabledragon/apiPayload/code/ErrorReasonDTO.java
@@ -1,0 +1,20 @@
+package com.example.vegetabledragon.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDTO {
+
+    private final HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess() {
+        return isSuccess;
+    }
+}

--- a/src/main/java/com/example/vegetabledragon/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/vegetabledragon/apiPayload/code/status/ErrorStatus.java
@@ -1,0 +1,60 @@
+package com.example.vegetabledragon.apiPayload.code.status;
+
+import com.example.vegetabledragon.apiPayload.code.BaseErrorCode;
+import com.example.vegetabledragon.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+    // 일반적인 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버에러, 관리자에게 문의바람."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    _NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "요청한 리소스가 없습니다."),
+
+    // CommentPermission
+    COMMENT_NOT_PERMISSION(HttpStatus.FORBIDDEN, "COMMENT4031", "댓글에 대한 수정/삭제 권한이 없습니다."),
+
+    // 회원 가입 시
+    USER_EMAIL_DUPLICATE(HttpStatus.CONFLICT, "USER4091", "중복된 이메일입니다."),
+    USER_NAME_DUPLICATE(HttpStatus.CONFLICT, "USER4092", "중복된 username입니다."),
+    USER_ANONYMOUS_DUPLICATE(HttpStatus.CONFLICT, "USER4093", "중복된 익명이름입니다."),
+    // 회원 조회 시
+    EMAIL_NOT_FOUND(HttpStatus.UNAUTHORIZED, "EMAIL4011", "이메일이 존재하지 않습니다."),
+    USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "USER4011", "가입되지 않은 사용자입니다."),
+    // 페이지 요청 시
+    PAGE_NOT_EXIST(HttpStatus.BAD_REQUEST, "PAGE4001", "요청 페이지 번호는 0 이상이어야 합니다."),
+
+    // 게시글 조회 시
+    POST_USERNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "POST4001", "username이 없습니다."),
+    POST_TITLE_NOT_EXIST(HttpStatus.BAD_REQUEST, "POST4002", "글의 제목은 필수입니다."),
+    POST_CONTENT_NOT_EXIST(HttpStatus.BAD_REQUEST, "POST4003", "글의 Content는 필수입니다."),
+    POST_CATEGORY_NOT_EXIST(HttpStatus.BAD_REQUEST, "POST4004", "글의 카테고리는 필수입니다."),
+    AUTHOR_DIFFERENT_WITH_LOGGEDIN(HttpStatus.UNAUTHORIZED, "POST4011", "로그인한 사용자와 글의 작성자가 다릅니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/example/vegetabledragon/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/example/vegetabledragon/apiPayload/exception/ExceptionAdvice.java
@@ -1,0 +1,22 @@
+package com.example.vegetabledragon.apiPayload.exception;
+
+import com.example.vegetabledragon.apiPayload.ApiResponse;
+import com.example.vegetabledragon.apiPayload.code.ErrorReasonDTO;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ExceptionAdvice {
+
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<?> handleGeneralException(GeneralException e, HttpServletRequest request) {
+        ErrorReasonDTO reason = e.getErrorReasonHttpStatus();
+        return new ResponseEntity<>(ApiResponse.onFailure(reason.getCode(), reason.getMessage(), null)
+                , reason.getHttpStatus());
+    }
+}

--- a/src/main/java/com/example/vegetabledragon/apiPayload/exception/GeneralException.java
+++ b/src/main/java/com/example/vegetabledragon/apiPayload/exception/GeneralException.java
@@ -1,0 +1,21 @@
+package com.example.vegetabledragon.apiPayload.exception;
+
+import com.example.vegetabledragon.apiPayload.code.BaseErrorCode;
+import com.example.vegetabledragon.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException{
+
+    private BaseErrorCode code;
+
+    public ErrorReasonDTO getReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/com/example/vegetabledragon/apiPayload/exception/handler/CommentHandler.java
+++ b/src/main/java/com/example/vegetabledragon/apiPayload/exception/handler/CommentHandler.java
@@ -1,0 +1,4 @@
+package com.example.vegetabledragon.apiPayload.exception.handler;
+
+public class CommentHandler {
+}

--- a/src/main/java/com/example/vegetabledragon/apiPayload/exception/handler/PostHandler.java
+++ b/src/main/java/com/example/vegetabledragon/apiPayload/exception/handler/PostHandler.java
@@ -1,0 +1,4 @@
+package com.example.vegetabledragon.apiPayload.exception.handler;
+
+public class PostHandler {
+}

--- a/src/main/java/com/example/vegetabledragon/apiPayload/exception/handler/UserHandler.java
+++ b/src/main/java/com/example/vegetabledragon/apiPayload/exception/handler/UserHandler.java
@@ -1,0 +1,4 @@
+package com.example.vegetabledragon.apiPayload.exception.handler;
+
+public class UserHandler {
+}

--- a/src/main/java/com/example/vegetabledragon/controller/CommentController.java
+++ b/src/main/java/com/example/vegetabledragon/controller/CommentController.java
@@ -3,7 +3,6 @@ package com.example.vegetabledragon.controller;
 import com.example.vegetabledragon.domain.Comment;
 import com.example.vegetabledragon.dto.CommentRequest;
 import com.example.vegetabledragon.dto.PasswordRequest;
-import com.example.vegetabledragon.exception.CommentNotPermissionException;
 import com.example.vegetabledragon.exception.PostNotFoundException;
 import com.example.vegetabledragon.exception.UnauthorizedException;
 import com.example.vegetabledragon.exception.UserNotFoundException;
@@ -28,7 +27,7 @@ public class CommentController {
     @PostMapping
     public ResponseEntity<Comment> addComment(@PathVariable Long postId,
                                               @RequestBody CommentRequest request,
-                                              HttpSession session) throws PostNotFoundException, UserNotFoundException {
+                                              HttpSession session){
         String sessionUsername = (String) session.getAttribute("loggedInUser"); // 오류 날 거 같음
         Comment saved = commentService.saveComment(postId, session, request);
 
@@ -46,7 +45,7 @@ public class CommentController {
     public ResponseEntity<Comment> updateComment(@PathVariable Long postId,
                                                  @PathVariable Long commentId,
                                                  @RequestBody CommentRequest request,
-                                                 HttpSession session) throws PostNotFoundException, UserNotFoundException, CommentNotPermissionException {
+                                                 HttpSession session) {
         Comment updated = commentService.updateComment(commentId, session, request);
         return ResponseEntity.ok(updated);
     }
@@ -55,18 +54,13 @@ public class CommentController {
     public ResponseEntity<Void> deleteComment(@PathVariable Long postId,
                                               @PathVariable Long commentId,
                                               @RequestBody PasswordRequest request,
-                                              HttpSession session) throws PostNotFoundException, UserNotFoundException, CommentNotPermissionException, UnauthorizedException {
+                                              HttpSession session) {
         String sessionsUsername = (String) session.getAttribute("loggedInUser");
 
-        try {
-//            log.info("[CommentController] 댓글 번호 - {} 삭제, 권한 요청 사용자 - {}", commentId, sessionsUsername);
-            commentService.deleteComment(commentId, sessionsUsername, request.getPassword());
+        //            log.info("[CommentController] 댓글 번호 - {} 삭제, 권한 요청 사용자 - {}", commentId, sessionsUsername);
+        commentService.deleteComment(commentId, sessionsUsername, request.getPassword());
 //            log.info("[CommentController] 댓글 번호 - {} 성공적으로 삭제", commentId);
-            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-        } catch (CommentNotPermissionException e) {
-//            log.error("[CommentController] 댓글 번호 - {} 소유자가 아닌 사용자가 삭제 시도 - {}", commentId, sessionsUsername);
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
 }

--- a/src/main/java/com/example/vegetabledragon/exception/CommentNotPermissionException.java
+++ b/src/main/java/com/example/vegetabledragon/exception/CommentNotPermissionException.java
@@ -1,8 +1,0 @@
-package com.example.vegetabledragon.exception;
-
-public class CommentNotPermissionException extends Exception {
-    public CommentNotPermissionException(String sessionUsername) {
-
-        super(sessionUsername + " Error : We think that it is not your comments. Please try again");
-    }
-}

--- a/src/main/java/com/example/vegetabledragon/service/CheckPermissionServiceImpl.java
+++ b/src/main/java/com/example/vegetabledragon/service/CheckPermissionServiceImpl.java
@@ -1,8 +1,9 @@
 package com.example.vegetabledragon.service;
 
+import com.example.vegetabledragon.apiPayload.code.status.ErrorStatus;
+import com.example.vegetabledragon.apiPayload.exception.GeneralException;
 import com.example.vegetabledragon.domain.Comment;
 import com.example.vegetabledragon.domain.UserType;
-import com.example.vegetabledragon.exception.CommentNotPermissionException;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -11,23 +12,23 @@ import java.util.Optional;
 public class CheckPermissionServiceImpl {
 
     // 익명 댓글의 경우 비밀번호 검증
-    public void checkPermissionForAnonymous(Comment comment, String sessionUsername, String password) throws CommentNotPermissionException {
+    public void checkPermissionForAnonymous(Comment comment, String sessionUsername, String password){
         if (comment.getUserType() == UserType.ANONYMOUS) { // 기존에 writer == "익명" 으로 비교했었는데, 하드코딩으로 비교하는 게 적절하지 않다고 생각해서 수정함.
             if (!comment.getPassword().equals(password)){
-                throw new CommentNotPermissionException(password);
+                throw new GeneralException(ErrorStatus.COMMENT_NOT_PERMISSION);
             }
         }
     }
 
     // 일반 댓글의 경우 작성자와 login한 User가 일치하는지 확인
-    public void checkPermissionForAuthenticatedUser(Comment comment, String sessionUsername) throws CommentNotPermissionException {
+    public void checkPermissionForAuthenticatedUser(Comment comment, String sessionUsername) {
         if (comment.getUser() == null || !comment.getUser().getUsername().equals(sessionUsername)) {
-            throw new CommentNotPermissionException(sessionUsername);
+            throw new GeneralException(ErrorStatus.COMMENT_NOT_PERMISSION);
         }
     }
 
 
-    public void validateCommentPermission(Comment comment, String sessionUsername, String password) throws CommentNotPermissionException {
+    public void validateCommentPermission(Comment comment, String sessionUsername, String password) {
         if (comment.getUser() == null) {
             checkPermissionForAnonymous(comment, sessionUsername, password);
         } else {

--- a/src/main/java/com/example/vegetabledragon/service/CommentService.java
+++ b/src/main/java/com/example/vegetabledragon/service/CommentService.java
@@ -2,18 +2,14 @@ package com.example.vegetabledragon.service;
 
 import com.example.vegetabledragon.domain.Comment;
 import com.example.vegetabledragon.dto.CommentRequest;
-import com.example.vegetabledragon.exception.CommentNotPermissionException;
-import com.example.vegetabledragon.exception.PostNotFoundException;
-import com.example.vegetabledragon.exception.UnauthorizedException;
-import com.example.vegetabledragon.exception.UserNotFoundException;
 import jakarta.servlet.http.HttpSession;
 
 import java.util.List;
 
 public interface CommentService {
 
-    Comment saveComment(Long postId, HttpSession session, CommentRequest request) throws PostNotFoundException, UserNotFoundException;
-    List<Comment> getCommentsByPost(Long postId) throws PostNotFoundException;
-    Comment updateComment(Long commentId, HttpSession session, CommentRequest request) throws PostNotFoundException, UserNotFoundException, CommentNotPermissionException;
-    void deleteComment(Long commentId, String sessionUsername, String password) throws CommentNotPermissionException, UnauthorizedException;
+    Comment saveComment(Long postId, HttpSession session, CommentRequest request);
+    List<Comment> getCommentsByPost(Long postId);
+    Comment updateComment(Long commentId, HttpSession session, CommentRequest request);
+    void deleteComment(Long commentId, String sessionUsername, String password);
 }

--- a/src/main/java/com/example/vegetabledragon/service/CommentServiceImpl.java
+++ b/src/main/java/com/example/vegetabledragon/service/CommentServiceImpl.java
@@ -1,14 +1,12 @@
 package com.example.vegetabledragon.service;
 
+import com.example.vegetabledragon.apiPayload.code.status.ErrorStatus;
+import com.example.vegetabledragon.apiPayload.exception.GeneralException;
 import com.example.vegetabledragon.domain.Comment;
 import com.example.vegetabledragon.domain.Post;
 import com.example.vegetabledragon.domain.User;
 import com.example.vegetabledragon.domain.UserType;
 import com.example.vegetabledragon.dto.CommentRequest;
-import com.example.vegetabledragon.exception.CommentNotPermissionException;
-import com.example.vegetabledragon.exception.PostNotFoundException;
-import com.example.vegetabledragon.exception.UnauthorizedException;
-import com.example.vegetabledragon.exception.UserNotFoundException;
 import com.example.vegetabledragon.repository.CommentRepository;
 import com.example.vegetabledragon.repository.PostRepository;
 import com.example.vegetabledragon.repository.UserRepository;
@@ -28,9 +26,9 @@ public class CommentServiceImpl implements CommentService {
     private final CheckPermissionServiceImpl checkPermissionService;
 
     @Override
-    public Comment saveComment(Long postId, HttpSession session, CommentRequest request) throws PostNotFoundException, UserNotFoundException {
+    public Comment saveComment(Long postId, HttpSession session, CommentRequest request){
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new PostNotFoundException(postId));
+                .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND));
         // set을 쓰는 것보다, 변수에 저장해서 한 번에 생성자 부르는 게 나아보인다.
 
         User user = null;
@@ -38,16 +36,12 @@ public class CommentServiceImpl implements CommentService {
         String password = null;
         UserType userType;
 
-//        Comment comment = new Comment();
-//        comment.setPost(post);
-//        comment.setComment(request.getComment());
-
         String sessionUsername = (String) session.getAttribute("loggedInUser");
 
         // Session 이 다른 거하고 유지되는지를 확인해야 한다.
         if (sessionUsername != null) {
             user = userRepository.findByUsername(sessionUsername)
-                    .orElseThrow(() -> new UserNotFoundException(sessionUsername));
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
             writer = user.getAnonymousName();
             userType = UserType.REGISTERED;
 
@@ -62,22 +56,23 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    public List<Comment> getCommentsByPost(Long postId) throws PostNotFoundException {
+    public List<Comment> getCommentsByPost(Long postId){
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new PostNotFoundException(postId));
+                .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND));
 
         return commentRepository.findByPost(post);
     }
 
     @Override
-    public Comment updateComment(Long commentId, HttpSession session, CommentRequest request) throws PostNotFoundException, UserNotFoundException, CommentNotPermissionException {
+    public Comment updateComment(Long commentId, HttpSession session, CommentRequest request){
         String sessionUsername = (String) session.getAttribute("loggedInUser");
         if (sessionUsername == null) sessionUsername = "익명";
 
         // 댓글 조회
         Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new RuntimeException("Comment not found"));
+                .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND));
 
+        System.out.println("paword" + request.getPassword());
         // 권한 확인
         checkPermissionService.validateCommentPermission(comment, sessionUsername, request.getPassword());
 
@@ -88,9 +83,9 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    public void deleteComment(Long commentId, String sessionUsername, String password) throws CommentNotPermissionException, UnauthorizedException {
+    public void deleteComment(Long commentId, String sessionUsername, String password){
         Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new RuntimeException("comment not find"));
+                .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND));
 
         // 권한 확인
         checkPermissionService.validateCommentPermission(comment, sessionUsername, password);


### PR DESCRIPTION
기존에 Class 만들어서 따로 처리하던것을 한번에 enum class로 처리할 수 있게끔 리팩토링 중입니다
- Comment 도메인을 우선적으로 리팩토링 하였습니다.

리팩토링 하던 과정에서 흐름 상 오류를 발견하였습니다.
- 비밀번호만 확인하는 api를 따로 만들어야 할 듯합니다
- 익명 댓글 수정 시에, 비밀번호 확인 절차가 댓글 수정까지 가서 이루어져서 약간 흐름이 꼬입니다.
- 익명 댓글 수정이 안되는 것은 아니라, 크게 문제는 안되긴 하는데, 리팩토링 하고 나서 시간나면은 만들어놓겠습니다